### PR TITLE
Fix file output format from dict repr to json.dumps

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -238,7 +238,7 @@ def upload_by_type(log_dict: dict):
         subsegment.put_annotation('type', log_type)
         subsegment.put_annotation('count', len(records))
 
-        data = '\n'.join(str(record) for record in records)
+        data = '\n'.join(json.dumps(record) for record in records)
         put_to_s3(key, BUCKET_NAME, data)
 
         xray_recorder.end_subsegment()


### PR DESCRIPTION
`str()` method converts dict to string with dict representation (`__repr__`), which is not valid JSON, but valid Python code.

Since we only care about JSON logs anyways, this PR fixes string conversion with `json.dumps`.