### PR TITLE
Add top-level JSON type checks

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -96,7 +96,7 @@ def append_to_dict(dictionary: dict, log_type: str, log_data: object, log_timest
 
     dictionary[log_type]['records'].append(log_data)
 
-    
+
 def normalize_kinesis_payload(p: dict):
     # Normalize messages from CloudWatch (subscription filters) and pass through anything else
     # https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/logs/SubscriptionFilters.html
@@ -133,7 +133,8 @@ def normalize_kinesis_payload(p: dict):
                         logger.debug(f"parsed payload: {payload_parsed}")
 
                         if type(payload_parsed) is not dict:
-                            logger.error(f"Top-level JSON data in CWL payload is not an object, giving up: {payload}")
+                            logger.error(f"Top-level JSON data in CWL payload is not an object, giving up: "
+                                         f"{payload_parsed}")
                             continue
 
                     except JSONDecodeError as e:
@@ -156,7 +157,7 @@ def normalize_kinesis_payload(p: dict):
             raise ValueError(f"Unknown messageType: {payload}")
     else:
         payloads.append(payload)
-        
+
     return payloads
 
 

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -21,8 +21,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 logger.info('Loading function')
 
-# when debug logging is needed, uncomment following lines:
-# logger = logging.getLogger()
+# when debug logging is needed, uncomment following line:
 # logger.setLevel(logging.DEBUG)
 
 # patch boto3 with X-Ray
@@ -98,29 +97,31 @@ def append_to_dict(dictionary: dict, log_type: str, log_data: object, log_timest
     dictionary[log_type]['records'].append(log_data)
 
     
-def normalize_kinesis_payload(payload: dict):
+def normalize_kinesis_payload(p: dict):
     # Normalize messages from CloudWatch (subscription filters) and pass through anything else
     # https://docs.aws.amazon.com/ja_jp/AmazonCloudWatch/latest/logs/SubscriptionFilters.html
 
-    logger.debug(f"normalizer input: {payload}")
+    logger.debug(f"normalizer input: {p}")
 
     payloads = []
 
-    if len(payload) < 1:
-        logger.error(f"Got weird record: \"{payload}\", skipping")
+    if len(p) < 1:
+        logger.error(f"Got weird record: \"{p}\", skipping")
         return payloads
 
     # check if data is JSON and parse
     try:
-        payload = json.loads(payload)
+        payload = json.loads(p)
+        if type(payload) is not dict:
+            logger.error(f"Top-level JSON data is not an object, giving up: {payload}")
+            return payloads
 
     except JSONDecodeError:
-        logger.error(f"Non-JSON data found: {payload}, giving up")
+        logger.error(f"Non-JSON data found: {p}, giving up")
         return payloads
 
     if 'messageType' in payload:
-        logger.debug(f"Got payload looking like CloudWatch Logs via subscription filters: "
-                     f"{payload}")
+        logger.debug(f"Got payload looking like CloudWatch Logs via subscription filters: {payload}")
 
         if payload['messageType'] == "DATA_MESSAGE":
             if 'logEvents' in payload:
@@ -131,7 +132,12 @@ def normalize_kinesis_payload(payload: dict):
                         payload_parsed = json.loads(event['message'])
                         logger.debug(f"parsed payload: {payload_parsed}")
 
-                    except JSONDecodeError:
+                        if type(payload_parsed) is not dict:
+                            logger.error(f"Top-level JSON data in CWL payload is not an object, giving up: {payload}")
+                            continue
+
+                    except JSONDecodeError as e:
+                        logger.debug(e)
                         logger.debug(f"Non-JSON data found inside CWL message: {event}, giving up")
                         continue
 

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "aws_iam_role_policy_attachment" "xray_access" {
 
 module "iam" {
   source  = "baikonur-oss/iam-nofile/aws"
-  version = "v1.0.1"
+  version = "v2.0.0"
 
   type = "lambda"
   name = var.name


### PR DESCRIPTION
Check if top-level JSON type is Object (when parsed, Python dict).

Avoid primitives like bool, int going through json.loads parsing section 